### PR TITLE
update to 4.0.4 version number to reduce user confusion

### DIFF
--- a/docs/getting-started/installation-monogame.mdx
+++ b/docs/getting-started/installation-monogame.mdx
@@ -70,12 +70,12 @@ To get started first add the `MonoGame.Extended.Content.Pipeline` NuGet package 
 <Tabs>
   <TabItem value="net-cli" label=".NET Cli" default>
     ```sh
-    dotnet add package MonoGame.Extended.Content.Pipeline --version 4.0.0
+    dotnet add package MonoGame.Extended.Content.Pipeline --version @mgeversion@
     ```
   </TabItem>
   <TabItem value="package-manager" label="Package Manager">
     ```sh
-    NuGet\Install-Package MonoGame.Extended.Content.Pipeline -Version 4.0.0
+    NuGet\Install-Package MonoGame.Extended.Content.Pipeline -Version @mgeversion@
     ```
     <small>
       This command is intended to be used within the Package Manager Console in Visual Studio, as it uses NuGet module's version of [Install-Package](https://docs.microsoft.com/nuget/reference/ps-reference/ps-ref-install-package)
@@ -83,7 +83,7 @@ To get started first add the `MonoGame.Extended.Content.Pipeline` NuGet package 
   </TabItem>
   <TabItem value="package-reference" label="Package Reference" default>
     ```xml
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.0" />
+    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="@mgeversion@" />
     ```
     <small>
         For projects that support [PackageReference](https://docs.microsoft.com/nuget/consume-packages/package-references-in-project-files), copy this XML node into the project file to reference the package. 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,7 +1,7 @@
 import { themes as prismThemes } from 'prism-react-renderer';
 
 const globalVariables = {
-  'mgeversion': '4.0.3'
+  'mgeversion': '4.0.4'
 }
 
 /** @type {import('@docusaurus/types').Config} */


### PR DESCRIPTION
This change bumps the version number to 4.0.4 to match the current nuget package versions.  Also updated the monogame page to use the variable instead of hard coded versions.