### PR TITLE
Fix the examples for FromFile and FromStream to work with current code

### DIFF
--- a/docs/features/fonts/bitmapfont/bitmapfont.md
+++ b/docs/features/fonts/bitmapfont/bitmapfont.md
@@ -85,7 +85,7 @@ Both methods are described in the sections below.
 To load the `BitmapFont` at runtime, ensure that the `.fnt` file and the texture files associated with it are in the same directory. They must be in the same directory; otherwise, loading will fail when attempting to load the textures. Then you can load them using the `BitmapFont.FromFile` or `BitmapFont.FromStream` methods. 
 
 :::caution
-Files need to be in the built output directory.  Don't forget to set the "Copy to Output Directory" to Copy If Newer under properties on each file (`.fnt` and `.tga`).
+Files need to be in the built output directory.  Don't forget to set the [Copy to Output Directory] to [Copy If Newer] under properties on each file (font file `.fnt` and bitmap file `.png`).
 :::
 
 **From File Example**

--- a/docs/features/fonts/bitmapfont/bitmapfont.md
+++ b/docs/features/fonts/bitmapfont/bitmapfont.md
@@ -85,8 +85,7 @@ Both methods are described in the sections below.
 To load the `BitmapFont` at runtime, ensure that the `.fnt` file and the texture files associated with it are in the same directory. They must be in the same directory; otherwise, loading will fail when attempting to load the textures. Then you can load them using the `BitmapFont.FromFile` or `BitmapFont.FromStream` methods. 
 
 :::caution
-1. Files need to be in the built output directory.  Don't forget to set the "Copy to Output Directory" to Copy If Newer under properties on each file (`.fnt` and `.tga`).
-2. 
+Files need to be in the built output directory.  Don't forget to set the "Copy to Output Directory" to Copy If Newer under properties on each file (`.fnt` and `.tga`).
 :::
 
 **From File Example**

--- a/docs/features/fonts/bitmapfont/bitmapfont.md
+++ b/docs/features/fonts/bitmapfont/bitmapfont.md
@@ -82,19 +82,24 @@ Now that you have the `.fnt` file and textures generated, you can use them in yo
 Both methods are described in the sections below.
 
 ### Loading From File At Runtime
-To load the `BitmapFont` at runtime, ensure that the `.fnt` file and the texture files associated with it are in the same directory. They must be in the same directory; otherwise, loading will fail when attempting to load the textures. Then you can load them using the `BitmapFont.FromFile` or `BitmapFont.FromStream` methods.
+To load the `BitmapFont` at runtime, ensure that the `.fnt` file and the texture files associated with it are in the same directory. They must be in the same directory; otherwise, loading will fail when attempting to load the textures. Then you can load them using the `BitmapFont.FromFile` or `BitmapFont.FromStream` methods. 
+
+:::caution
+1. Files need to be in the built output directory.  Don't forget to set the "Copy to Output Directory" to Copy If Newer under properties on each file (`.fnt` and `.tga`).
+2. 
+:::
 
 **From File Example**
 
 ```cs
-BitmapFont bmfont = BitmapFont.FromFile("path/to/my-font.fnt");
+BitmapFont bmfont = BitmapFont.FromFile(GraphicsDevice, "path/to/my-font.fnt");
 ```
 
 **From Stream Example**
 ```cs
-using(var stream = TitleContainer.OpenStream("Content/my-font.fnt"))
+using(var stream = TitleContainer.OpenStream(GraphicsDevice, "Content/my-font.fnt"))
 {
-    BitmapFont bmfont = BitmapFont.FromStream(stream);
+    BitmapFont bmfont = BitmapFont.FromStream(GraphicsDevice, stream, "Content/my-font.fnt");
 }
 ```
 


### PR DESCRIPTION
Fixes #88

Image showing font loaded both ways with the corrected documentation code (Passing in the graphics device)

![image](https://github.com/user-attachments/assets/3fba4358-a5f7-46e1-b445-722d9b5827a6)

